### PR TITLE
Add simple Telegram redirect bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Codex_2
+# Simple Telegram Redirect Bot
+
+This repository contains a minimal Telegram bot written in Python. It forwards any incoming message from a user directly to a specified admin chat.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export the bot token and admin chat ID as environment variables:
+   ```bash
+   export BOT_TOKEN="<your-bot-token>"
+   export ADMIN_CHAT_ID=<admin-user-id>
+   ```
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```
+
+The bot will start polling and forward every received message to the admin.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,29 @@
+import os
+from telegram import Update
+from telegram.ext import ApplicationBuilder, MessageHandler, ContextTypes, filters
+
+ADMIN_CHAT_ID = int(os.environ.get("ADMIN_CHAT_ID", "0"))
+BOT_TOKEN = os.environ.get("BOT_TOKEN")
+
+async def forward_to_admin(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if update.message and ADMIN_CHAT_ID:
+        await context.bot.forward_message(
+            chat_id=ADMIN_CHAT_ID,
+            from_chat_id=update.message.chat_id,
+            message_id=update.message.message_id,
+        )
+
+
+def main() -> None:
+    if not BOT_TOKEN:
+        raise ValueError("BOT_TOKEN environment variable not set")
+    if not ADMIN_CHAT_ID:
+        raise ValueError("ADMIN_CHAT_ID environment variable not set")
+
+    application = ApplicationBuilder().token(BOT_TOKEN).build()
+    application.add_handler(MessageHandler(filters.ALL, forward_to_admin))
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot==20.3


### PR DESCRIPTION
## Summary
- implement a minimal Telegram bot that forwards all messages to an admin chat
- add requirements.txt with python-telegram-bot
- document setup instructions

## Testing
- `pip install -r requirements.txt`
- `python bot.py` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f465a1dec832eadb7bc119870833d